### PR TITLE
Media Processor

### DIFF
--- a/HTTP/src/css/components/_MediaPreview.css
+++ b/HTTP/src/css/components/_MediaPreview.css
@@ -15,7 +15,12 @@
   .ThumbWrapper {
     width: 200px;
     height: 200px;
+    margin: 3px auto 0;
     @apply relative text-center flex flex-col justify-center items-center;
+
+    img.thumbnail {
+      @apply rounded shadow;
+    }
 
     .IconsWrapper {
       position: absolute;

--- a/HTTP/src/js/Components/MediaPreview/MediaPreview.tsx
+++ b/HTTP/src/js/Components/MediaPreview/MediaPreview.tsx
@@ -12,7 +12,7 @@ export default function MediaPreview({upload}: MediaPreviewProps) {
     <div className="MediaPreview" data-upload={upload.upload.id} data-media={upload.media.id} data-sha256={upload.media.sha256} data-md5={upload.media.md5} data-mime={upload.media.mime}>
       <div className="ThumbWrapper">
         <a href={`/view/${upload.upload.id}`} target="_blank" className={upload.state.MODERATION_QUEUED ? 'blurred hover-clear' : ''}>
-          <img src={`/thumb/${upload.upload.id}`} alt={`Thumbnail for upload ${upload.upload.id}`}/>
+          <img src={`/thumb/${upload.upload.id}`} alt={`Thumbnail for upload ${upload.upload.id}`} className="thumbnail"/>
         </a>
         <div className="IconsWrapper">
           <div className="OverlayIcon" title={`This upload is a${isImage ? 'n image' : 'video'}`}>

--- a/HTTP/src/js/Pages/Upload/PageUpload.tsx
+++ b/HTTP/src/js/Pages/Upload/PageUpload.tsx
@@ -44,6 +44,8 @@ export default function PageUpload(props: PageUploadProps) {
 
               if (ur.errors.length > 0) {
                 setError(ur.errors.join('\n'));
+              } else {
+                setError('An internal server error occurred. Please reload and try again.');
               }
             }
           }
@@ -90,7 +92,7 @@ export default function PageUpload(props: PageUploadProps) {
               <FileInput label="Image/Video" onFiles={handleFiles} invalid={fileErrors && fileErrors.length > 0} errorText={fileErrors}/>
               <label><input ref={cbPrivate} type="checkbox" name="private"/> Private</label>
               <button type="button" className="block w-full bg-green-500 py-1 mt-1 shadow-sm rounded text-white hover:bg-green-600 focus:bg-green-600 disabled:cursor-not-allowed disabled:bg-green-700 disabled:text-gray-400" onClick={handleClick} disabled={!canUpload}>
-                {uploading ? (<><Spinner/> Uploading...</>) : `Upload Another`}
+                {uploading ? (<><Spinner/> Uploading...</>) : `Upload`}
               </button>
             </form>
           </>
@@ -102,7 +104,7 @@ export default function PageUpload(props: PageUploadProps) {
           </>
         )}
         {error ? (
-          <p className="text-red-500 whitespace-pre-wrap">{error}</p>
+          <p className="text-red-500 whitespace-pre-wrap mt-2">{error}</p>
         ) : null}
       </>
     </CenteredBlockPage>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Full-stack tag-based image archive.
 * Java 15
 * NodeJS 15.8.0+ (front-end builds)
   * The maven build will automatically download a NodeJS distribution for automated builds, you only need NodeJS yourself if you want to build the front-end manually.
+* FFMPEG
+  * Required by the MediaProcessor. Tested with v4.4, but may work for prior versions.
 
 # License
 

--- a/SCHEMA/yuugure.dbml
+++ b/SCHEMA/yuugure.dbml
@@ -53,7 +53,6 @@ table media_meta { // meta is attached as a second step and not present on initi
   video          boolean [not null]
   video_duration real    [not null, default: `0`]
   has_audio      boolean [not null, default: `false`]
-  audio_duration real    [not null, default: `0`]
 
   indexes {
     media [unique, name: "media_meta_media_unique"]

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,17 @@
       <artifactId>jeromq</artifactId>
       <version>0.5.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>bson</artifactId>
+      <version>4.3.0-beta3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.kokorin.jaffree</groupId>
+      <artifactId>jaffree</artifactId>
+      <version>2021.05.31</version>
+    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/com/mtinge/yuugure/App.java
+++ b/src/main/java/com/mtinge/yuugure/App.java
@@ -4,6 +4,7 @@ import com.mtinge.yuugure.core.Config;
 import com.mtinge.yuugure.services.database.Database;
 import com.mtinge.yuugure.services.http.WebServer;
 import com.mtinge.yuugure.services.messaging.Messaging;
+import com.mtinge.yuugure.services.processor.MediaProcessor;
 import com.mtinge.yuugure.services.redis.Redis;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ public class App {
   private static Database database;
   private static Redis redis;
   private static Messaging messaging;
+  private static MediaProcessor mediaProcessor;
 
   public App() {
     try {
@@ -31,6 +33,7 @@ public class App {
       database = new Database();
       redis = new Redis();
       messaging = new Messaging();
+      mediaProcessor = new MediaProcessor();
       webServer = new WebServer();
     } catch (Exception e) {
       throw new Error("Failed to instantiate services.", e);
@@ -42,6 +45,7 @@ public class App {
       redis.init();
       database.init();
       messaging.init();
+      mediaProcessor.init();
       webServer.init();
     } catch (Exception e) {
       throw new Error("Failed to initialize services.", e);
@@ -51,6 +55,7 @@ public class App {
       redis.start();
       database.start();
       messaging.start();
+      mediaProcessor.start();
       webServer.start();
     } catch (Exception e) {
       throw new Error("Failed to start services.", e);
@@ -75,6 +80,10 @@ public class App {
 
   public static Messaging messaging() {
     return messaging;
+  }
+
+  public static MediaProcessor mediaProcessor() {
+    return mediaProcessor;
   }
 
   public static boolean isDebug() {

--- a/src/main/java/com/mtinge/yuugure/core/Config.java
+++ b/src/main/java/com/mtinge/yuugure/core/Config.java
@@ -128,12 +128,14 @@ public final class Config {
 
     @AllArgsConstructor
     public static final class Bind {
-      public final String internal;
-      public final String external;
+      public final String broadcast;
+      public final String internalSupplier;
+      public final String internalConsolidator;
 
       public Bind() {
-        this.internal = "tcp://127.0.0.1:50328";
-        this.external = "tcp://0.0.0.0:39250";
+        this.broadcast = "tcp://127.0.0.1:50328";
+        this.internalSupplier = "tcp://0.0.0.0:58378";
+        this.internalConsolidator = "tcp://0.0.0.0:59951";
       }
     }
   }

--- a/src/main/java/com/mtinge/yuugure/data/postgres/DBMedia.java
+++ b/src/main/java/com/mtinge/yuugure/data/postgres/DBMedia.java
@@ -1,15 +1,42 @@
 package com.mtinge.yuugure.data.postgres;
 
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
 import org.jdbi.v3.core.mapper.RowMapper;
 
+import java.util.Objects;
+
 @AllArgsConstructor
+@ToString
 public class DBMedia {
   public final int id;
   public final String sha256;
   public final String md5;
   public final String phash;
   public final String mime;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DBMedia dbMedia = (DBMedia) o;
+
+    return id == dbMedia.id
+      && Objects.equals(sha256, dbMedia.sha256)
+      && Objects.equals(md5, dbMedia.md5)
+      && Objects.equals(phash, dbMedia.phash)
+      && Objects.equals(mime, dbMedia.mime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, sha256, md5, phash, mime);
+  }
 
   public static RowMapper<DBMedia> Mapper = (r, c) ->
     new DBMedia(
@@ -19,4 +46,69 @@ public class DBMedia {
       r.getString("phash"),
       r.getString("mime")
     );
+
+  public static DBMedia readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "id" -> builder.id(reader.readInt32());
+        case "sha256" -> builder.sha256(reader.readString());
+        case "md5" -> builder.md5(reader.readString());
+        case "phash" -> builder.phash(reader.readString());
+        case "mime" -> builder.mime(reader.readString());
+        default -> System.err.println("Unknown name in DBMedia document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    DBMedia.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, DBMedia media) {
+    writer.writeStartDocument();
+
+
+    writer.writeName("id");
+    writer.writeInt32(media.id);
+
+    writer.writeName("sha256");
+    writer.writeString(media.sha256);
+
+    writer.writeName("md5");
+    writer.writeString(media.md5);
+
+    writer.writeName("phash");
+    writer.writeString(media.phash);
+
+    writer.writeName("mime");
+    writer.writeString(media.mime);
+
+
+    writer.writeEndDocument();
+  }
+
+  @Setter
+  @Accessors(fluent = true)
+  public static final class Builder {
+    private int id;
+    private String sha256;
+    private String md5;
+    private String phash;
+    private String mime;
+
+    public Builder() {
+      //
+    }
+
+    public DBMedia build() {
+      return new DBMedia(id, sha256, md5, phash, mime);
+    }
+  }
 }

--- a/src/main/java/com/mtinge/yuugure/data/postgres/DBMediaMeta.java
+++ b/src/main/java/com/mtinge/yuugure/data/postgres/DBMediaMeta.java
@@ -12,7 +12,6 @@ public class DBMediaMeta {
   public final boolean video;
   public final long videoDuration;
   public final boolean hasAudio;
-  public final long audioDuration;
 
   public static final RowMapper<DBMediaMeta> Mapper = (r, ctx) -> new DBMediaMeta(
     r.getInt("id"),
@@ -21,7 +20,6 @@ public class DBMediaMeta {
     r.getInt("height"),
     r.getBoolean("video"),
     r.getLong("video_duration"),
-    r.getBoolean("has_audio"),
-    r.getLong("audio_duration")
+    r.getBoolean("has_audio")
   );
 }

--- a/src/main/java/com/mtinge/yuugure/data/postgres/DBProcessingQueue.java
+++ b/src/main/java/com/mtinge/yuugure/data/postgres/DBProcessingQueue.java
@@ -1,11 +1,20 @@
 package com.mtinge.yuugure.data.postgres;
 
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
 import org.jdbi.v3.core.mapper.RowMapper;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
 
 @AllArgsConstructor
+@ToString
 public class DBProcessingQueue {
   public final int id;
   public final int upload;
@@ -15,13 +24,112 @@ public class DBProcessingQueue {
   public final String errorText;
   public final boolean finished;
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DBProcessingQueue that = (DBProcessingQueue) o;
+
+    return id == that.id
+      && upload == that.upload
+      && dequeued == that.dequeued
+      && errored == that.errored
+      && finished == that.finished
+      && queuedAt.toInstant().toEpochMilli() == that.queuedAt.toInstant().toEpochMilli()
+      && Objects.equals(errorText, that.errorText);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, upload, queuedAt, dequeued, errored, errorText, finished);
+  }
+
   public static final RowMapper<DBProcessingQueue> Mapper = (r, ctx) -> new DBProcessingQueue(
     r.getInt("id"),
     r.getInt("upload"),
-    r.getTimestamp("queuedAt"),
+    r.getTimestamp("queued_at"),
     r.getBoolean("dequeued"),
     r.getBoolean("errored"),
     r.getString("error_text"),
     r.getBoolean("finished")
   );
+
+  public static DBProcessingQueue readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "id" -> builder.id(reader.readInt32());
+        case "upload" -> builder.upload(reader.readInt32());
+        case "queuedAt" -> builder.queuedAt(Timestamp.from(Instant.ofEpochMilli(reader.readInt64())));
+        case "dequeued" -> builder.dequeued(reader.readBoolean());
+        case "errored" -> builder.errored(reader.readBoolean());
+        case "errorText" -> {
+          try {
+            builder.errorText(reader.readString());
+          } catch (Exception e) {
+            // ignored, assumed empty string.
+          }
+        }
+        case "finished" -> builder.finished(reader.readBoolean());
+        default -> System.err.println("Unknown name in DBProcessingQueue document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    DBProcessingQueue.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, DBProcessingQueue dbProcessingQueue) {
+    writer.writeStartDocument();
+
+
+    writer.writeName("id");
+    writer.writeInt32(dbProcessingQueue.id);
+
+    writer.writeName("upload");
+    writer.writeInt32(dbProcessingQueue.upload);
+
+    writer.writeName("queuedAt");
+    writer.writeInt64(dbProcessingQueue.queuedAt.toInstant().toEpochMilli());
+
+    writer.writeName("dequeued");
+    writer.writeBoolean(dbProcessingQueue.dequeued);
+
+    writer.writeName("errored");
+    writer.writeBoolean(dbProcessingQueue.errored);
+
+    if (dbProcessingQueue.errorText != null) {
+      writer.writeName("errorText");
+      writer.writeString(dbProcessingQueue.errorText);
+    }
+
+    writer.writeName("finished");
+    writer.writeBoolean(dbProcessingQueue.finished);
+
+
+    writer.writeEndDocument();
+  }
+
+  @Setter
+  @Accessors(fluent = true)
+  public static final class Builder {
+    private int id;
+    private int upload;
+    private Timestamp queuedAt;
+    private boolean dequeued;
+    private boolean errored;
+    private String errorText;
+    private boolean finished;
+
+    public DBProcessingQueue build() {
+      return new DBProcessingQueue(id, upload, queuedAt, dequeued, errored, errorText, finished);
+    }
+  }
 }

--- a/src/main/java/com/mtinge/yuugure/data/postgres/DBUpload.java
+++ b/src/main/java/com/mtinge/yuugure/data/postgres/DBUpload.java
@@ -1,11 +1,20 @@
 package com.mtinge.yuugure.data.postgres;
 
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
 import org.jdbi.v3.core.mapper.RowMapper;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
 
 @AllArgsConstructor
+@ToString
 public class DBUpload {
   public final int id;
   public final int media;
@@ -13,6 +22,25 @@ public class DBUpload {
   public final int owner;
   public final Timestamp uploadDate;
   public final long state;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DBUpload dbUpload = (DBUpload) o;
+
+    return id == dbUpload.id
+      && media == dbUpload.media
+      && parent == dbUpload.parent
+      && owner == dbUpload.owner
+      && state == dbUpload.state
+      && uploadDate.toInstant().toEpochMilli() == dbUpload.uploadDate.toInstant().toEpochMilli();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, media, parent, owner, uploadDate, state);
+  }
 
   public static final RowMapper<DBUpload> Mapper = (r, c) -> new DBUpload(
     r.getInt("id"),
@@ -22,4 +50,70 @@ public class DBUpload {
     r.getTimestamp("upload_date"),
     r.getLong("state")
   );
+
+  public static DBUpload readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "id" -> builder.id(reader.readInt32());
+        case "media" -> builder.media(reader.readInt32());
+        case "parent" -> builder.parent(reader.readInt32());
+        case "owner" -> builder.owner(reader.readInt32());
+        case "uploadDate" -> builder.uploadDate(Timestamp.from(Instant.ofEpochMilli(reader.readInt64())));
+        case "state" -> builder.state(reader.readInt64());
+        default -> System.err.println("Unknown name in DBUpload document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    DBUpload.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, DBUpload upload) {
+    writer.writeStartDocument();
+
+
+    writer.writeName("id");
+    writer.writeInt32(upload.id);
+
+    writer.writeName("media");
+    writer.writeInt32(upload.media);
+
+    writer.writeName("parent");
+    writer.writeInt32(upload.parent);
+
+    writer.writeName("owner");
+    writer.writeInt32(upload.owner);
+
+    writer.writeName("uploadDate");
+    writer.writeInt64(upload.uploadDate.toInstant().toEpochMilli());
+
+    writer.writeName("state");
+    writer.writeInt64(upload.state);
+
+
+    writer.writeEndDocument();
+  }
+
+  @Setter
+  @Accessors(fluent = true)
+  public static final class Builder {
+    private int id;
+    private int media;
+    private int parent;
+    private int owner;
+    private Timestamp uploadDate;
+    private long state;
+
+    public DBUpload build() {
+      return new DBUpload(id, media, parent, owner, uploadDate, state);
+    }
+  }
 }

--- a/src/main/java/com/mtinge/yuugure/data/processor/MediaMeta.java
+++ b/src/main/java/com/mtinge/yuugure/data/processor/MediaMeta.java
@@ -1,0 +1,120 @@
+package com.mtinge.yuugure.data.processor;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.Objects;
+
+@Getter
+@Setter
+@Accessors(fluent = true, chain = true)
+@ToString
+public class MediaMeta {
+  @Setter(AccessLevel.NONE)
+  private int media;
+  private int width = 0;
+  private int height = 0;
+  private boolean video = false;
+  private double videoDuration = 0;
+  private boolean hasAudio = false;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MediaMeta mediaMeta = (MediaMeta) o;
+
+    return media == mediaMeta.media
+      && width == mediaMeta.width
+      && height == mediaMeta.height
+      && video == mediaMeta.video
+      && Double.compare(mediaMeta.videoDuration, videoDuration) == 0
+      && hasAudio == mediaMeta.hasAudio;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(media, width, height, video, videoDuration, hasAudio);
+  }
+
+  public MediaMeta(int media) {
+    this.media = media;
+  }
+
+  public static MediaMeta readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "media" -> builder.media(reader.readInt32());
+        case "width" -> builder.width(reader.readInt32());
+        case "height" -> builder.height(reader.readInt32());
+        case "video" -> builder.video(reader.readBoolean());
+        case "videoDuration" -> builder.videoDuration(reader.readDouble());
+        case "hasAudio" -> builder.hasAudio(reader.readBoolean());
+        default -> System.err.println("Unknown name in MediaMeta document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    MediaMeta.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, MediaMeta meta) {
+    writer.writeStartDocument();
+
+
+    writer.writeName("media");
+    writer.writeInt32(meta.media);
+
+    writer.writeName("width");
+    writer.writeInt32(meta.width);
+
+    writer.writeName("height");
+    writer.writeInt32(meta.height);
+
+    writer.writeName("video");
+    writer.writeBoolean(meta.video);
+
+    writer.writeName("videoDuration");
+    writer.writeDouble(meta.videoDuration);
+
+    writer.writeName("hasAudio");
+    writer.writeBoolean(meta.hasAudio);
+
+
+    writer.writeEndDocument();
+  }
+
+  @Setter
+  @Accessors(fluent = true, chain = true)
+  public static final class Builder {
+    private int media;
+    private int width = 0;
+    private int height = 0;
+    private boolean video = false;
+    private double videoDuration = 0;
+    private boolean hasAudio = false;
+
+    public MediaMeta build() {
+      return new MediaMeta(media)
+        .width(width)
+        .height(height)
+        .video(video)
+        .videoDuration(videoDuration)
+        .hasAudio(hasAudio);
+    }
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/data/processor/ProcessableUpload.java
+++ b/src/main/java/com/mtinge/yuugure/data/processor/ProcessableUpload.java
@@ -1,0 +1,89 @@
+package com.mtinge.yuugure.data.processor;
+
+import com.mtinge.yuugure.data.postgres.DBMedia;
+import com.mtinge.yuugure.data.postgres.DBProcessingQueue;
+import com.mtinge.yuugure.data.postgres.DBUpload;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.Objects;
+
+@AllArgsConstructor
+@ToString
+public class ProcessableUpload {
+  public final DBProcessingQueue queueItem;
+  public final DBUpload upload;
+  public final DBMedia media;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProcessableUpload that = (ProcessableUpload) o;
+
+    return Objects.equals(queueItem, that.queueItem)
+      && Objects.equals(upload, that.upload)
+      && Objects.equals(media, that.media);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(queueItem, upload, media);
+  }
+
+  public static ProcessableUpload readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "queueItem" -> builder.queueItem(DBProcessingQueue.readFrom(reader));
+        case "upload" -> builder.upload(DBUpload.readFrom(reader));
+        case "media" -> builder.media(DBMedia.readFrom(reader));
+        default -> System.err.println("Unknown name in ProcessableUpload document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    ProcessableUpload.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, ProcessableUpload upload) {
+    writer.writeStartDocument();
+
+
+    writer.writeName("queueItem");
+    upload.queueItem.writeTo(writer);
+
+    writer.writeName("upload");
+    upload.upload.writeTo(writer);
+
+    writer.writeName("media");
+    upload.media.writeTo(writer);
+
+
+    writer.writeEndDocument();
+  }
+
+  @Setter
+  @Accessors(fluent = true)
+  public static class Builder {
+    private DBProcessingQueue queueItem;
+    private DBUpload upload;
+    private DBMedia media;
+
+    public ProcessableUpload build() {
+      return new ProcessableUpload(queueItem, upload, media);
+    }
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/data/processor/ProcessorResult.java
+++ b/src/main/java/com/mtinge/yuugure/data/processor/ProcessorResult.java
@@ -1,0 +1,95 @@
+package com.mtinge.yuugure.data.processor;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Getter
+@Setter
+@Accessors(fluent = true, chain = true)
+@RequiredArgsConstructor
+public class ProcessorResult {
+  private boolean success = false;
+  private String message = "";
+  private MediaMeta meta;
+  private final ProcessableUpload dequeued;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProcessorResult that = (ProcessorResult) o;
+    return success == that.success && message.equals(that.message) && meta.equals(that.meta) && dequeued.equals(that.dequeued);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(success, message, meta, dequeued);
+  }
+
+  public static ProcessorResult readFrom(BsonReader reader) {
+    var builder = new Builder();
+
+    reader.readStartDocument();
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      var name = reader.readName();
+      switch (name) {
+        case "success" -> builder.success(reader.readBoolean());
+        case "message" -> builder.message(reader.readString());
+        case "meta" -> builder.meta(MediaMeta.readFrom(reader));
+        case "dequeued" -> builder.dequeued(ProcessableUpload.readFrom(reader));
+        default -> System.err.println("Unknown name in ProcessorResult document: " + name);
+      }
+    }
+    reader.readEndDocument();
+
+    return builder.build();
+  }
+
+  public void writeTo(BsonWriter writer) {
+    ProcessorResult.writeTo(writer, this);
+  }
+
+  public static void writeTo(BsonWriter writer, ProcessorResult result) {
+    if (result.meta == null) throw new IllegalArgumentException("The provided ProcessorResult has a null meta.");
+
+    writer.writeStartDocument();
+
+
+    writer.writeName("success");
+    writer.writeBoolean(result.success);
+
+    writer.writeName("message");
+    writer.writeString(Optional.ofNullable(result.message).orElse(""));
+
+    writer.writeName("dequeued");
+    result.dequeued.writeTo(writer);
+
+    writer.writeName("meta");
+    result.meta.writeTo(writer);
+
+
+    writer.writeEndDocument();
+  }
+
+  @RequiredArgsConstructor
+  @Setter
+  @Accessors(fluent = true, chain = true)
+  public static final class Builder {
+    private boolean success;
+    private String message;
+    private MediaMeta meta;
+    private ProcessableUpload dequeued;
+
+    public ProcessorResult build() {
+      return new ProcessorResult(dequeued).success(success).message(message).meta(meta);
+    }
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/services/http/ETagHelper.java
+++ b/src/main/java/com/mtinge/yuugure/services/http/ETagHelper.java
@@ -1,0 +1,74 @@
+package com.mtinge.yuugure.services.http;
+
+import io.undertow.server.handlers.resource.PathResourceManager;
+import io.undertow.util.ETag;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.CRC32;
+
+/**
+ * An ETag generator that uses CRC-32 for speed and caches based on MTime.
+ */
+public class ETagHelper implements PathResourceManager.ETagFunction {
+  private static final Logger logger = LoggerFactory.getLogger(ETagHelper.class);
+
+  private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+  private static final Object _monitor = new Object();
+
+  public ETag generate(Path path) {
+    try {
+      var file = path.toFile();
+      var modified = Files.getLastModifiedTime(path);
+
+      // Check the cache, if we don't get a hit or our hit is old then recompute and store.
+      synchronized (_monitor) {
+        var key = file.toString();
+        var cached = cache.get(key);
+        if (cached == null || modified.toMillis() > cached.mtime) {
+          try (var fis = new FileInputStream(file)) {
+            // Compute a CRC32 hash
+            var crc32 = new CRC32();
+
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = fis.read(chunk)) > 0) {
+              crc32.update(chunk, 0, read);
+            }
+
+            // Get the sha256 (filename) to add onto the CRC32
+            String name = file.getName();
+            var liof = name.lastIndexOf('.');
+            if (liof > -1) {
+              name = name.substring(0, liof);
+            }
+
+            // Prepend the filename we extracted to avoid direct CRC32 collisions
+            String etag = name + ";" + Long.toHexString(crc32.getValue());
+
+            // Store the new cached object
+            cached = new CacheEntry(modified.toMillis(), etag);
+            cache.put(key, cached);
+          }
+        }
+
+        return new ETag(false, cached.hash);
+      }
+    } catch (Exception e) {
+      logger.error("Failed to generate ETag for path {}.", path.getFileName().toString(), e);
+    }
+
+    return null;
+  }
+
+  @AllArgsConstructor
+  private static final class CacheEntry {
+    public final long mtime;
+    public final String hash;
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/services/processor/MediaProcessor.java
+++ b/src/main/java/com/mtinge/yuugure/services/processor/MediaProcessor.java
@@ -1,0 +1,289 @@
+package com.mtinge.yuugure.services.processor;
+
+import com.github.kokorin.jaffree.StreamType;
+import com.github.kokorin.jaffree.ffmpeg.FFmpeg;
+import com.github.kokorin.jaffree.ffmpeg.Filter;
+import com.github.kokorin.jaffree.ffmpeg.UrlInput;
+import com.github.kokorin.jaffree.ffmpeg.UrlOutput;
+import com.mtinge.yuugure.App;
+import com.mtinge.yuugure.core.ThreadFactories;
+import com.mtinge.yuugure.data.processor.MediaMeta;
+import com.mtinge.yuugure.data.processor.ProcessableUpload;
+import com.mtinge.yuugure.data.processor.ProcessorResult;
+import com.mtinge.yuugure.services.IService;
+import com.mtinge.yuugure.services.messaging.Messaging;
+import lombok.Getter;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.io.BasicOutputBuffer;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * <p>The MediaProcessor's job is to take an upload and perform tasks that require external tools
+ * such as thumbnail generation and metadata tagging. Uses FFMPEG and FFPROBE extensively for
+ * tagging and validation.</p>
+ * <p>MediaProcessor is purposefully written to be naïve since it is possible for a processor to
+ * have died part-way through. It is also possible for a half/already-finished processor to be
+ * started again via DB manipulation. The process should never fail just because an unexpected path
+ * exists (e.g. thumbnail), and no preexisting state should be misconstrued as evidence of a
+ * previously successful run.</p>
+ * <p>
+ * To facilitate this statelessness, the processor is destructive. Existing files will be
+ * overwritten because it is unknown if the processor died half way through writing, and even if it
+ * didn't, we explicitly want them replaced if we've restarted a processor. This also facilitates
+ * re-processing existing uploads in the case of the processor being updated to add new tags.
+ * </p>
+ */
+public class MediaProcessor implements IService {
+  private static final Logger logger = LoggerFactory.getLogger(MediaProcessor.class);
+
+  @Getter
+  ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(), ThreadFactories.prefixed("MediaProcessor/"));
+  @Getter
+  LinkedList<Worker> workers = new LinkedList<>();
+
+  public MediaProcessor() {
+    //
+  }
+
+  @Override
+  public void init() throws Exception {
+    // Sockets bind immediately when creating a worker so we do initialization directly in start().
+  }
+
+  @Override
+  public void start() throws Exception {
+    var context = App.messaging().context();
+    var bindIncoming = App.config().zeromq.bind.internalSupplier;
+    var bindOutgoing = App.config().zeromq.bind.internalConsolidator;
+
+    for (var i = 0; i < Runtime.getRuntime().availableProcessors(); i++) {
+      var worker = new Worker(context, bindIncoming, bindOutgoing);
+      workers.add(worker);
+      executor.submit(worker);
+    }
+  }
+
+  @Override
+  public void stop() throws Exception {
+    for (var worker : workers) {
+      worker.close();
+      worker.wake();
+    }
+  }
+
+  public void wakeWorkers() {
+    for (var worker : workers) {
+      worker.wake();
+    }
+  }
+
+  public static ProcessorResult Process(ProcessableUpload dequeued) {
+    if (dequeued == null) return null;
+
+    logger.debug("Beginning processing of {}", dequeued.media.sha256);
+
+    // Harvest metadata
+    var fullPath = Path.of(App.config().upload.finalDir, dequeued.media.sha256 + ".full");
+    var thumbPath = Path.of(App.config().upload.finalDir, dequeued.media.sha256 + ".thumb");
+    var result = new ProcessorResult(dequeued);
+    var isJpeg = dequeued.media.mime.toLowerCase().endsWith("jpeg");
+
+    // ffprobe has a hard time with the jpeg so we'll set the format specifically if needed
+    var streams = ProbeStreams.forPath(fullPath, isJpeg ? "mjpeg" : null);
+    if (streams != null) {
+      // Images are reported as a video codec, so we should always have a "video" stream. If we
+      // don't, user uploaded an unprocessable file as we can't extract a thumbnail.
+      if (streams.video != null) {
+        var meta = new MediaMeta(dequeued.media.id)
+          .width(Optional.ofNullable(streams.video.getCodedWidth()).orElse(streams.video.getWidth()))
+          .height(Optional.ofNullable(streams.video.getCodedWidth()).orElse(streams.video.getHeight()))
+          .video(dequeued.media.mime.toLowerCase().startsWith("video/"))
+          .videoDuration(Optional.ofNullable(Optional.ofNullable(streams.video.getDuration()).orElse(streams.format.getDuration())).orElse(0f)) // try to extract from the video stream first, then the format specifier
+          .hasAudio(false); // audio detection is handled with an ffmpeg filter later.
+
+        if (streams.audio != null) {
+          var volumeData = VolumeData.detect(fullPath);
+          if (volumeData != null) {
+            meta.hasAudio(volumeData.meanVolume > -80 || volumeData.maxVolume > -80);
+          } // else: invalid audio stream, no detectable volume
+        }
+
+        // ensure we attach our metadata
+        result.meta(meta);
+
+        // Create thumbnail
+        if (createThumbnail(fullPath, thumbPath, meta.video() ? ((long) Math.floor(meta.videoDuration() / 8)) : 0, isJpeg ? "mjpeg" : null)) {
+          // TODO automated tagging should happen here when tagging is implemented.
+          return result.success(true);
+        } else {
+          // else: failed to create thumbnail
+          return result.success(false).message("Thumbnail generation failed.");
+        }
+      } else {
+        // else: invalid file, no video streams
+        return result.success(false).message("No video streams.");
+      }
+    } else {
+      // else: invalid file, no streams
+      return result.success(false).message("No video/audio streams.");
+    }
+  }
+
+  public static boolean createThumbnail(Path fullPath, Path thumbPath, @Nullable Long seek, @Nullable String format) {
+    if (seek == null) {
+      seek = 0L;
+    }
+
+    try {
+      var input = UrlInput.fromPath(fullPath).setPosition(seek);
+      var ffmpeg = FFmpeg.atPath()
+        .addInput(input)
+        .setFilter(StreamType.VIDEO, Filter.withName("scale")
+          .addArgumentEscaped("'if(gt(a,200/200),200,-1)':'if(gt(a,200/200),-1,200)'")
+        )
+        .addArguments("-sws_flags", "bicubic+full_chroma_inp")
+        .setOverwriteOutput(true)
+        .addOutput(
+          UrlOutput.toPath(thumbPath)
+            .setFrameCount(StreamType.VIDEO, 1L)
+            .setFormat("apng")
+        );
+      if (format != null) {
+        input.setFormat(format);
+      }
+      ffmpeg.execute();
+
+      return true;
+    } catch (Exception e) {
+      logger.error("Failed to create thumbnail for path {}.", fullPath, e);
+      return false;
+    }
+  }
+
+  private static final class Worker implements Runnable, Closeable {
+    private static final Logger logger = LoggerFactory.getLogger("MediaProcessor/Worker");
+
+    // NOTE: The monitor is only used for wait/notify, data synchronization already happens on two
+    //       levels - first on a DB level with row locks and second on a functional level within
+    //       the work supplier in the Messaging class. This already may be too much synchronization
+    //       so I'm hesitant to add a third layer, however if it's necessary in the future it will
+    //       be an easy addition.
+    private final Object monitor = new Object();
+    private final AtomicBoolean shutdownRequested = new AtomicBoolean(false);
+    private final AtomicBoolean closeCalled = new AtomicBoolean(false);
+    private final ZMQ.Socket socketIncoming;
+    private final ZMQ.Socket socketOutgoing;
+
+    public Worker(ZContext context, String bindIncoming, String bindOutgoing) {
+      this.socketIncoming = context.createSocket(SocketType.REQ);
+      this.socketOutgoing = context.createSocket(SocketType.PUSH);
+
+      if (!this.socketIncoming.connect(bindIncoming)) {
+        throw new IllegalStateException("Failed to bind the incoming socket.");
+      }
+
+      if (!this.socketOutgoing.connect(bindOutgoing)) {
+        throw new IllegalStateException("Failed to bind the outgoing socket.");
+      }
+    }
+
+    @Override
+    public void run() {
+      while (!shutdownRequested.get()) {
+        if (closeCalled.get()) {
+          return;
+        }
+
+        // get work
+        if (!socketIncoming.send(new byte[]{1})) {
+          logger.warn("Failed to request work");
+        } else {
+          var received = socketIncoming.recv(0);
+          if (received == null) {
+            continue;
+          }
+
+          boolean shouldSleep = received.length == 1;
+          if (received.length == 1) {
+            // got an opcode
+            if (received[0] == Messaging.NOT_ACCEPTABLE) {
+              throw new IllegalStateException("Received the NOT_ACCEPTABLE response to a work payload request. Cannot continue.");
+            }
+          } else {
+            var parsed = ProcessableUpload.readFrom(new BsonBinaryReader(ByteBuffer.wrap(received)));
+            if (parsed != null) {
+              logger.info("Received job for upload {}.", parsed.upload.id);
+              var result = MediaProcessor.Process(parsed);
+
+              var bob = new BasicOutputBuffer();
+              var writer = new BsonBinaryWriter(bob);
+              result.writeTo(writer);
+
+              byte[] bytes = null;
+              try (var bos = new ByteArrayOutputStream()) {
+                bob.pipe(bos);
+                bytes = bos.toByteArray();
+              } catch (Exception e) {
+                logger.error("Failed to serialize result for upload {}.", parsed.upload.id, e);
+              }
+
+              if (bytes != null) {
+                socketOutgoing.send(bytes);
+              }
+            } else {
+              shouldSleep = true;
+              logger.error("Received invalid ProcessableUpload. Processing has been skipped.");
+            }
+          }
+
+          if (shouldSleep) {
+            synchronized (monitor) {
+              // We didn't get work so wait for either a notification or for 30s to pass before
+              // trying again.
+              try {
+                monitor.wait(30000);
+              } catch (InterruptedException ie) {
+                // ignored - this can happen for a multitude of reasons, one of which being a notify
+              }
+            }
+          }
+        }
+      }
+    }
+
+    public void wake() {
+      synchronized (monitor) {
+        monitor.notify();
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closeCalled.compareAndSet(false, true)) {
+        if (this.socketIncoming != null) {
+          this.socketIncoming.close();
+        }
+        if (this.socketOutgoing != null) {
+          this.socketOutgoing.close();
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/services/processor/ProbeStreams.java
+++ b/src/main/java/com/mtinge/yuugure/services/processor/ProbeStreams.java
@@ -1,0 +1,65 @@
+package com.mtinge.yuugure.services.processor;
+
+import com.github.kokorin.jaffree.LogLevel;
+import com.github.kokorin.jaffree.StreamType;
+import com.github.kokorin.jaffree.ffprobe.FFprobe;
+import com.github.kokorin.jaffree.ffprobe.Format;
+import com.github.kokorin.jaffree.ffprobe.Stream;
+import lombok.AllArgsConstructor;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+
+@AllArgsConstructor
+public class ProbeStreams {
+  private static final Logger logger = LoggerFactory.getLogger(ProbeStreams.class);
+
+  public final Stream video;
+  public final Stream audio;
+  public final Format format;
+
+  public static ProbeStreams forPath(Path path, @Nullable String format) {
+    try {
+      var ffprobe = FFprobe.atPath()
+        .setShowStreams(true)
+        .setLogLevel(LogLevel.INFO)
+        .setCountFrames(true)
+        .setShowStreams(true)
+        .setShowFormat(true)
+        .setInput(path);
+
+      if (format != null) {
+        ffprobe.setFormat(format);
+      }
+
+      var probed = ffprobe.execute();
+      Stream videoStream = null;
+      Stream audioStream = null;
+
+      for (var stream : probed.getStreams()) {
+        if (audioStream == null && stream.getCodecType().equals(StreamType.AUDIO)) {
+          audioStream = stream;
+        }
+        if (videoStream == null && stream.getCodecType().equals(StreamType.VIDEO)) {
+          videoStream = stream;
+        }
+
+        if (audioStream != null && videoStream != null) {
+          break;
+        }
+      }
+
+      if (videoStream == null && audioStream == null) {
+        logger.warn("No streams extracted for {}.", path.toString());
+        return null;
+      }
+
+      return new ProbeStreams(videoStream, audioStream, probed.getFormat());
+    } catch (Exception e) {
+      logger.error("Failed to extract streams for path {}.", path.toString(), e);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/mtinge/yuugure/services/processor/VolumeData.java
+++ b/src/main/java/com/mtinge/yuugure/services/processor/VolumeData.java
@@ -1,0 +1,65 @@
+package com.mtinge.yuugure.services.processor;
+
+import com.github.kokorin.jaffree.StreamType;
+import com.github.kokorin.jaffree.ffmpeg.FFmpeg;
+import com.github.kokorin.jaffree.ffmpeg.Filter;
+import com.github.kokorin.jaffree.ffmpeg.NullOutput;
+import com.github.kokorin.jaffree.ffmpeg.UrlInput;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+public class VolumeData {
+  private static final Logger logger = LoggerFactory.getLogger(VolumeData.class);
+
+  public final double meanVolume;
+  public final double maxVolume;
+
+  public static VolumeData detect(Path fullPath) {
+    try {
+      var lines = new LinkedList<String>();
+      FFmpeg.atPath()
+        .addInput(
+          UrlInput.fromPath(fullPath)
+        )
+        .setFilter(StreamType.AUDIO, Filter.withName("volumedetect"))
+        .addOutput(
+          new NullOutput(false)
+            .setDuration(60, TimeUnit.SECONDS)
+        )
+        .setOutputListener(line -> {
+          if (line.startsWith("[Parsed_volumedetect")) {
+            lines.add(line);
+          }
+        })
+        .execute();
+
+      // collect output into KVPs for processing
+      var vars = lines.stream()
+        .map(line -> (line.substring(line.lastIndexOf(']') + 1)).split(":"))
+        .collect(Collectors.toMap(strings -> strings[0].trim(), strings -> strings[1].trim()));
+
+      double meanVolume = -91L;
+      double maxVolume = -91L;
+
+      // process the vars we need for the MediaProcessor
+      if (vars.containsKey("mean_volume") && vars.get("mean_volume").contains(" dB")) {
+        meanVolume = Double.parseDouble(vars.get("mean_volume").split(" ")[0]);
+      }
+      if (vars.containsKey("max_volume") && vars.get("max_volume").contains(" dB")) {
+        maxVolume = Double.parseDouble(vars.get("max_volume").split(" ")[0]);
+      }
+
+      return new VolumeData(meanVolume, maxVolume);
+    } catch (Exception e) {
+      logger.error("Failed to extract VolumeData for path {}.", fullPath, e);
+    }
+    return null;
+  }
+}

--- a/src/main/resources/defaults.json
+++ b/src/main/resources/defaults.json
@@ -26,8 +26,9 @@
   },
   "zeromq": {
     "bind": {
-      "internal": "tcp://127.0.0.1:50328",
-      "external": "tcp://0.0.0.0:39250"
+      "broadcast": "tcp://127.0.0.1:50328",
+      "internalSupplier": "tcp://0.0.0.0:58378",
+      "internalConsolidator": "tcp://0.0.0.0:59951"
     }
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
   <logger name="com.zaxxer.hikari.pool" level="WARN"/>
   <logger name="com.zaxxer.hikari.HikariConfig" level="ERROR"/>
   <logger name="org.xnio.nio" level="INFO"/>
+  <logger name="com.github.kokorin.jaffree" level="ERROR"/>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/src/test/java/com/mtinge/yuugure/data/BsonConversionTests.java
+++ b/src/test/java/com/mtinge/yuugure/data/BsonConversionTests.java
@@ -1,0 +1,113 @@
+package com.mtinge.yuugure.data;
+
+import com.mtinge.yuugure.core.States;
+import com.mtinge.yuugure.data.postgres.DBMedia;
+import com.mtinge.yuugure.data.postgres.DBProcessingQueue;
+import com.mtinge.yuugure.data.postgres.DBUpload;
+import com.mtinge.yuugure.data.processor.MediaMeta;
+import com.mtinge.yuugure.data.processor.ProcessableUpload;
+import com.mtinge.yuugure.data.processor.ProcessorResult;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.io.BasicOutputBuffer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+@DisplayName("MediaProcessor BSON Converters")
+public class BsonConversionTests {
+  @Test
+  @DisplayName("ProcessableUpload round-tripping")
+  void ProcessableUploadRoundTrip() throws Exception {
+    var media = new DBMedia(1, "sha256", "md5", "phash", "mime");
+    var upload = new DBUpload(1, media.id, 0, 1, Timestamp.from(Instant.now().minus(Duration.ofDays(2))), States.Upload.MODERATION_QUEUED);
+    var processingQueue = new DBProcessingQueue(1, upload.id, Timestamp.from(upload.uploadDate.toInstant().plusSeconds(1)), true, false, null, false);
+    var processable = new ProcessableUpload(processingQueue, upload, media);
+
+    var bob = new BasicOutputBuffer();
+    var writer = new BsonBinaryWriter(bob);
+    processable.writeTo(writer);
+
+    byte[] bytes;
+    try (var bos = new ByteArrayOutputStream()) {
+      bob.pipe(bos);
+      bytes = bos.toByteArray();
+    }
+    Assertions.assertNotEquals(0, bytes.length);
+
+    var reader = new BsonBinaryReader(ByteBuffer.wrap(bytes));
+    var deserialized = ProcessableUpload.readFrom(reader);
+
+    // Ensure none null
+    Assertions.assertNotNull(deserialized);
+    Assertions.assertNotNull(deserialized.media);
+    Assertions.assertNotNull(deserialized.upload);
+    Assertions.assertNotNull(deserialized.queueItem);
+
+    // Ensure the round-trip correctly re-encoded all of the values
+    Assertions.assertEquals(deserialized.media, media);
+    Assertions.assertEquals(deserialized.upload, upload);
+    Assertions.assertEquals(deserialized.queueItem, processingQueue);
+  }
+
+  @Test
+  @DisplayName("ProcessorResult writer throws for null meta")
+  void ProcessorResultNullMeta() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      var bob = new BasicOutputBuffer();
+      var writer = new BsonBinaryWriter(bob);
+      new ProcessorResult.Builder().build().writeTo(writer);
+    });
+  }
+
+  @Test
+  @DisplayName("ProcessorResult round-tripping")
+  void ProcessorResultRoundTrip() throws Exception {
+    var media = new DBMedia(1, "sha256", "md5", "phash", "mime");
+    var upload = new DBUpload(1, media.id, 0, 1, Timestamp.from(Instant.now().minus(Duration.ofDays(2))), States.Upload.MODERATION_QUEUED);
+    var processingQueue = new DBProcessingQueue(1, upload.id, Timestamp.from(upload.uploadDate.toInstant().plusSeconds(1)), true, false, null, false);
+    var processable = new ProcessableUpload(processingQueue, upload, media);
+
+    var meta = new MediaMeta.Builder()
+      .media(media.id)
+      .width(1920)
+      .height(1080)
+      .video(false)
+      .hasAudio(false)
+      .videoDuration(0)
+      .build();
+    var result = new ProcessorResult.Builder()
+      .dequeued(processable)
+      .meta(meta)
+      .message("An internal server error occurred.")
+      .success(false)
+      .build();
+
+    var bob = new BasicOutputBuffer();
+    var writer = new BsonBinaryWriter(bob);
+    result.writeTo(writer);
+
+    byte[] bytes;
+    try (var bos = new ByteArrayOutputStream()) {
+      bob.pipe(bos);
+      bytes = bos.toByteArray();
+    }
+    Assertions.assertNotEquals(0, bytes.length);
+
+    var reader = new BsonBinaryReader(ByteBuffer.wrap(bytes));
+    var deserialized = ProcessorResult.readFrom(reader);
+
+    Assertions.assertNotNull(deserialized);
+    Assertions.assertNotNull(deserialized.meta());
+    Assertions.assertNotNull(deserialized.dequeued());
+    Assertions.assertNotNull(deserialized.message());
+
+    Assertions.assertEquals(deserialized, result);
+  }
+}


### PR DESCRIPTION
This PR brings bindings and workflows for the Media Processor. The Media Processor is in charge of taking a fully realized upload and executing tasks that require external tools - metadata harvesting, thumbnail generation, automated tagging, and anything else we may need in the future.

MediaProcessor relies on FFMPEG for metadata harvesting and audio detection. The README has been updated to reflect this requirement change.

The MediaProcessor work queue is implemented using ZeroMQ messaging. Justification (from commit message 2b16b5f):
> I wrote the media processing queue to use ZeroMQ instead of supplying data directly to a class so that I can distribute processors over the network. There are however limitations to that with the current app infrastructure given that files are stored on the local disk. When we move over to a distributed fs where workers can gain access easier across a network then there's a chance that the processors will be distributed in clusters. Writing the code to be distributable now solves the complexity later. There's also a chance that the processor will be extracted from the codebaes and rewritten in another language for distribution, e.g. nodejs which handles event-driven workloads excellently.
> 
> BSON was chosen as the package de/serializer because of its adoption in MongoDB. I explored Procbuffer and Avro, but MongoDB was better for our use case - it allows us to write our own serializers and doesn't require code generation or sending schemas over the wire with each packet. It also has adoption in most other languages and will allow for better portability across different languages.
